### PR TITLE
Add metadata for Flatpak External Data Checker

### DIFF
--- a/fi.skyjake.Lagrange.json
+++ b/fi.skyjake.Lagrange.json
@@ -30,7 +30,11 @@
                     "type": "git",
                     "url": "https://github.com/skyjake/lagrange",
                     "tag": "v1.13.7-1",
-                    "commit": "dc063c2e29d34ea1695f3908117c90c8ee3d3e42"
+                    "commit": "dc063c2e29d34ea1695f3908117c90c8ee3d3e42",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d+.]+)(?:\\-\\d+)?$"
+                    }
                 }
             ]
         }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+
+{
+    "publish-delay-hours": 0,
+    "automerge-flathubbot-prs": true
+}


### PR DESCRIPTION
Add metadata for Flatpak External Data Checker to enable automatic updates. The regex pattern matches version tags like `v1.13.7-1` or `v1.13.7`.