### PR TITLE
Remove x11 socket because of fallback-x11

### DIFF
--- a/fi.skyjake.Lagrange.json
+++ b/fi.skyjake.Lagrange.json
@@ -5,7 +5,6 @@
     "sdk": "org.freedesktop.Sdk",
     "command": "lagrange",
     "finish-args": [
-        "--socket=x11",
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--share=ipc",

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,3 @@
-
 {
-    "publish-delay-hours": 0,
     "automerge-flathubbot-prs": true
 }


### PR DESCRIPTION
Due to a lint error, removing the x11 socket. The documentation says:

> To support older Flatpak releases, specify both x11 and fallback-x11. The fallback-x11 option takes precedence when both are supported.

Apparently these older Flatpak releases aren't supported any more?